### PR TITLE
Eliminate compiler warning in FlashStorage.cpp

### DIFF
--- a/src/Hardware/FlashStorage.cpp
+++ b/src/Hardware/FlashStorage.cpp
@@ -6,7 +6,7 @@
 extern int __flash_start__,	__flash_end__;
 
 //#define DEBUG 1
-#if (DEBUG)
+#ifdef DEBUG
 #include "UI/MessageLog.hpp"
 #define dbg(fmt, args...)		do { MessageLog::AppendMessageF("%s(%d): " fmt , __FUNCTION__, __LINE__, ##args); } while(0)
 


### PR DESCRIPTION
Change `#if (DEBUG)` to `#ifdef DEBUG` to eliminate compiler warning about `DEBUG` being undefined