### PR TITLE
ignore .vscode in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ src/OEM
 # Misc
 .settings/language.settings.xml
 compile_commands.json
+
+# IDEs
+.vscode


### PR DESCRIPTION
since the build does not strictly depend on eclipse any more due to cmake support, one might use vscode.
this commit add a local vscode configuration folder to .gitignore